### PR TITLE
Download stl

### DIFF
--- a/openforge/app/routes/tags.py
+++ b/openforge/app/routes/tags.py
@@ -86,19 +86,35 @@ def query_tags():
                 cursor, accept, require, deny, paging, limit
             )
             count = tag_sql.tag_search_blueprint_count(cursor, accept, require, deny)
+            start_count = 0
+            if len(bp_data) > 0:
+                start_count = tag_sql.tag_search_blueprint_start_count(
+                    cursor, accept, require, deny, bp_data[0]["id"]
+                )
             tag_count = tag_sql.tag_search_tag_count(cursor, accept, require, deny)
             tag_count = {"|".join(tag["tag"]): tag["tag_count"] for tag in tag_count}
             bps = _merge_blueprint_tag_data(bp_data, tag_data)
             bps = _merge_blueprint_image_data(bps, image_data)
-            next_paging = bps[-1]["id"] if len(bps) > 0 else None
+            paging = _munge_paging(bps, count, start_count)
             return jsonify(
                 {
-                    "total_count": count,
-                    "next_paging": next_paging,
+                    "paging": paging,
                     "blueprints": bps,
                     "tag_counts": tag_count,
                 }
             )
+
+
+def _munge_paging(bps: list[dict], total_count: int, start_count: int) -> dict:
+    previous_token = bps[0]["id"] if len(bps) > 0 else None
+    next_token = bps[-1]["id"] if len(bps) > 0 else None
+    paging = {
+        "previous_token": previous_token,
+        "next_token": next_token,
+        "total_count": total_count,
+        "start_count": start_count,
+    }
+    return paging
 
 
 def _merge_blueprint_tag_data(bp_data: list[dict], tag_data: list[dict]) -> list[dict]:

--- a/openforge/app/routes/tags.py
+++ b/openforge/app/routes/tags.py
@@ -74,16 +74,17 @@ def query_tags():
                 accept = request.json.get("accept", [])
                 require = request.json.get("require", [])
                 deny = request.json.get("deny", [])
-            paging = request.args.get("paging")
+            next = request.args.get("next")
+            previous = request.args.get("previous")
             limit = request.args.get("limit", 20)
             bp_data = tag_sql.tag_search_blueprints(
-                cursor, accept, require, deny, paging, limit
+                cursor, accept, require, deny, next, previous, limit
             )
             tag_data = tag_sql.tag_search_tags(
-                cursor, accept, require, deny, paging, limit
+                cursor, accept, require, deny, next, previous, limit
             )
             image_data = tag_sql.tag_search_blueprint_images(
-                cursor, accept, require, deny, paging, limit
+                cursor, accept, require, deny, next, previous, limit
             )
             count = tag_sql.tag_search_blueprint_count(cursor, accept, require, deny)
             start_count = 0

--- a/openforge/db/sql/tags.py
+++ b/openforge/db/sql/tags.py
@@ -113,14 +113,15 @@ def tag_search_blueprints(
     accept: list[str],
     require: list[str],
     deny: list[str],
-    paging: uuid.UUID | None = None,
+    next: uuid.UUID | None = None,
+    previous: uuid.UUID | None = None,
     limit: int = 20,
 ) -> list[uuid.UUID]:
     parts = [
         sql.SQL("SELECT *"),
         sql.SQL("  FROM blueprints"),
         sql.SQL("  WHERE blueprints.id IN ("),
-        _query_tags_basics(accept, require, deny, paging, limit),
+        _query_tags_basics(accept, require, deny, next, previous, limit),
         sql.SQL("  )"),
         sql.SQL("  ORDER BY blueprints.id"),
     ]
@@ -134,14 +135,15 @@ def tag_search_tags(
     accept: list[str],
     require: list[str],
     deny: list[str],
-    paging: uuid.UUID | None = None,
+    next: uuid.UUID | None = None,
+    previous: uuid.UUID | None = None,
     limit: int = 20,
 ) -> list[uuid.UUID]:
     parts = [
         sql.SQL("SELECT *"),
         sql.SQL("  FROM tags AS bptags"),
         sql.SQL("  WHERE bptags.blueprint_id IN ("),
-        _query_tags_basics(accept, require, deny, paging, limit),
+        _query_tags_basics(accept, require, deny, next, previous, limit),
         sql.SQL("  )"),
         sql.SQL("  ORDER BY bptags.blueprint_id"),
     ]
@@ -155,7 +157,8 @@ def tag_search_blueprint_images(
     accept: list[str],
     require: list[str],
     deny: list[str],
-    paging: uuid.UUID | None = None,
+    next: uuid.UUID | None = None,
+    previous: uuid.UUID | None = None,
     limit: int = 20,
 ) -> list[dict]:
     parts = [
@@ -165,7 +168,7 @@ def tag_search_blueprint_images(
         sql.SQL("  FROM images"),
         sql.SQL("    JOIN blueprint_images AS bpi ON images.id = bpi.image_id"),
         sql.SQL("  WHERE bpi.blueprint_id IN ("),
-        _query_tags_basics(accept, require, deny, paging, limit),
+        _query_tags_basics(accept, require, deny, next, previous, limit),
         sql.SQL("  )"),
         sql.SQL("  ORDER BY bpi.blueprint_id"),
     ]
@@ -235,7 +238,8 @@ def _query_tags_basics(
     accept: list[str],
     require: list[str],
     deny: list[str],
-    paging: uuid.UUID | None = None,
+    next: uuid.UUID | None = None,
+    previous: uuid.UUID | None = None,
     limit: int = 20,
     do_limit: bool = True,
 ) -> sql.Composed:
@@ -259,13 +263,20 @@ SELECT DISTINCT bp.id
         deny_parts.append(_query_tags_deny(deny))
         deny_parts.append(sql.SQL("    )"))
 
-    if paging:
+    if next:
         query_parts.append(
             sql.SQL(
-                "  %s bp.id > {paging}" % ("WHERE" if len(query_parts) <= 1 else "AND")
-            ).format(paging=sql.Literal(paging))
+                "  %s bp.id > {next}" % ("WHERE" if len(query_parts) <= 1 else "AND")
+            ).format(next=sql.Literal(next))
         )
-    end_parts = [sql.SQL("  ORDER BY bp.id")]
+    elif previous:
+        query_parts.append(
+            sql.SQL(
+                "  %s bp.id < {previous}"
+                % ("WHERE" if len(query_parts) <= 1 else "AND")
+            ).format(previous=sql.Literal(previous))
+        )
+    end_parts = [sql.SQL("  ORDER BY bp.id %s" % ("DESC" if previous else "ASC"))]
     if do_limit:
         end_parts.append(sql.SQL("  LIMIT {limit}").format(limit=sql.Literal(limit)))
     query = sql.Composed(query_parts + deny_parts + end_parts)

--- a/openforge/db/sql/tags.py
+++ b/openforge/db/sql/tags.py
@@ -125,7 +125,6 @@ def tag_search_blueprints(
         sql.SQL("  ORDER BY blueprints.id"),
     ]
     query = sql.Composed(parts)
-    print(query.as_string())
     curs.execute(query)
     return curs.fetchall()
 
@@ -147,7 +146,6 @@ def tag_search_tags(
         sql.SQL("  ORDER BY bptags.blueprint_id"),
     ]
     query = sql.Composed(parts)
-    print(query.as_string())
     curs.execute(query)
     return curs.fetchall()
 
@@ -172,7 +170,6 @@ def tag_search_blueprint_images(
         sql.SQL("  ORDER BY bpi.blueprint_id"),
     ]
     query = sql.Composed(parts)
-    print(query.as_string())
     curs.execute(query)
     return curs.fetchall()
 
@@ -189,6 +186,26 @@ def tag_search_blueprint_count(
         sql.SQL("  WHERE blueprints.id IN ("),
         _query_tags_basics(accept, require, deny, do_limit=False),
         sql.SQL("  )"),
+    ]
+    query = sql.Composed(parts)
+    curs.execute(query)
+    return curs.fetchone()["count"]
+
+
+def tag_search_blueprint_start_count(
+    curs: cursor,
+    accept: list[str],
+    require: list[str],
+    deny: list[str],
+    first: uuid.UUID,
+) -> int:
+    parts = [
+        sql.SQL("SELECT COUNT(*)"),
+        sql.SQL("  FROM blueprints"),
+        sql.SQL("  WHERE blueprints.id IN ("),
+        _query_tags_basics(accept, require, deny, do_limit=False),
+        sql.SQL("  )"),
+        sql.SQL("  AND blueprints.id < {first}").format(first=sql.Literal(first)),
     ]
     query = sql.Composed(parts)
     curs.execute(query)
@@ -230,15 +247,23 @@ SELECT DISTINCT bp.id
         )
     ]
     query_parts.append(_query_tags_include(accept, require))
+    if query_parts[-1] == sql.Composed([]):
+        query_parts = query_parts[:-1]
     deny_parts = []
     if len(deny) > 0:
-        deny_parts.append(sql.SQL("    AND bp.id NOT IN ("))
+        deny_parts.append(
+            sql.SQL(
+                "    %s bp.id NOT IN (" % ("WHERE" if len(query_parts) <= 1 else "AND")
+            )
+        )
         deny_parts.append(_query_tags_deny(deny))
         deny_parts.append(sql.SQL("    )"))
 
     if paging:
         query_parts.append(
-            sql.SQL("  AND bp.id > {paging}").format(paging=sql.Literal(paging))
+            sql.SQL(
+                "  %s bp.id > {paging}" % ("WHERE" if len(query_parts) <= 1 else "AND")
+            ).format(paging=sql.Literal(paging))
         )
     end_parts = [sql.SQL("  ORDER BY bp.id")]
     if do_limit:

--- a/openforge/openapi/schemas/openapi.yaml
+++ b/openforge/openapi/schemas/openapi.yaml
@@ -323,8 +323,14 @@ paths:
       description: Returns blueprint ids
       parameters:
         - in: query
-          name: paging
-          description: Paging id
+          name: next
+          description: Paging id for next page
+          required: false
+          schema:
+            type: string
+        - in: query
+          name: previous
+          description: Paging id for previous page
           required: false
           schema:
             type: string

--- a/openforge/openapi/schemas/openapi.yaml
+++ b/openforge/openapi/schemas/openapi.yaml
@@ -348,10 +348,17 @@ paths:
               schema:
                 type: object
                 properties:
-                  total_count:
-                    type: integer
-                  next_paging:
-                    type: string
+                  paging:
+                    type: object
+                    properties:
+                      next_token:
+                        type: string
+                      previous_token:
+                        type: string
+                      total_count:
+                        type: integer
+                      start_count:
+                        type: integer
                   blueprints:
                     type: array
                     items:

--- a/src/components/blueprint-container.tsx
+++ b/src/components/blueprint-container.tsx
@@ -36,12 +36,6 @@ const BlueprintContainer = ({ blueprint }: { blueprint: Blueprint | null }) => {
       <h2>{blueprint.blueprint_name}</h2>
       <p><strong>Type:</strong> {blueprint.blueprint_type}</p>
       <p><strong>Created:</strong> {blueprint.created_at}, <strong>Updated:</strong> {earlierDate.toLocaleString()}, <strong>Size:</strong> {formatFileSize(blueprint.file_size)}</p>
-      <p><strong>Storage Address:</strong> <a 
-        href={blueprint.storage_address}
-        download={blueprint.file_name}
-      >
-        {blueprint.storage_address}
-      </a></p>
       <p>{blueprint.tags.map(tag => (
         <button
           key={tag}
@@ -51,6 +45,12 @@ const BlueprintContainer = ({ blueprint }: { blueprint: Blueprint | null }) => {
           {tag}
         </button>
       ))}</p>
+      <p><strong><a 
+        href={blueprint.storage_address}
+        download={blueprint.file_name}
+      >
+        Download
+      </a></strong></p>
       <div>
         {blueprint.images.map((image) => (
           <div key={image.id}>

--- a/src/components/blueprint-container.tsx
+++ b/src/components/blueprint-container.tsx
@@ -2,31 +2,58 @@
 
 import React from 'react';
 import { Blueprint } from '@/types';
+import useBlueprintStore from '@/stores/blueprints-store';
+
+const formatFileSize = (bytes: number): string => {
+  const units = ['B', 'KB', 'MB', 'GB', 'TB'];
+  let size = bytes;
+  let unitIndex = 0;
+
+  while (size >= 1024 && unitIndex < units.length - 1) {
+    size /= 1024;
+    unitIndex++;
+  }
+
+  return `${Math.round(size * 100) / 100} ${units[unitIndex]}`;
+};
 
 const BlueprintContainer = ({ blueprint }: { blueprint: Blueprint | null }) => {
+  const addTag = useBlueprintStore((state) => state.addTag);
+
   if (!blueprint) {
     return <div>No blueprint selected</div>;
   }
+
+  const earlierDate = new Date(
+    Math.min(
+      new Date(blueprint.file_changed_at).getTime(),
+      new Date(blueprint.file_modified_at).getTime()
+    )
+  );
 
   return (
     <div className='blueprintContainer'>
       <h2>{blueprint.blueprint_name}</h2>
       <p><strong>Type:</strong> {blueprint.blueprint_type}</p>
-      <p><strong>Created At:</strong> {blueprint.created_at}</p>
-      <p><strong>File Changed At:</strong> {blueprint.file_changed_at}</p>
-      <p><strong>File Modified At:</strong> {blueprint.file_modified_at}</p>
-      <p><strong>File Name:</strong> {blueprint.file_name}</p>
-      <p><strong>File Size:</strong> {blueprint.file_size}</p>
-      <p><strong>Full Name:</strong> {blueprint.full_name}</p>
-      <p><strong>ID:</strong> {blueprint.id}</p>
-      <p><strong>Storage Address:</strong> <a href={blueprint.storage_address}>{blueprint.storage_address}</a></p>
-      <p><strong>Tags:</strong> {blueprint.tags.join(', ')}</p>
-      <p><strong>Updated At:</strong> {blueprint.updated_at}</p>
+      <p><strong>Created:</strong> {blueprint.created_at}, <strong>Updated:</strong> {earlierDate.toLocaleString()}, <strong>Size:</strong> {formatFileSize(blueprint.file_size)}</p>
+      <p><strong>Storage Address:</strong> <a 
+        href={blueprint.storage_address}
+        download={blueprint.file_name}
+      >
+        {blueprint.storage_address}
+      </a></p>
+      <p>{blueprint.tags.map(tag => (
+        <button
+          key={tag}
+          onClick={() => addTag(tag)}
+          className="inline-block px-2 py-1 mr-2 text-sm bg-blue-100 hover:bg-blue-200 rounded-md cursor-pointer"
+        >
+          {tag}
+        </button>
+      ))}</p>
       <div>
-        <h3>Images</h3>
         {blueprint.images.map((image) => (
           <div key={image.id}>
-            <p><strong>{image.image_name}</strong></p>
             <img src={image.image_url} alt={image.image_name} />
           </div>
         ))}

--- a/src/components/blueprint-container.tsx
+++ b/src/components/blueprint-container.tsx
@@ -24,8 +24,8 @@ const BlueprintContainer = ({ blueprint }: { blueprint: Blueprint | null }) => {
     return <div>No blueprint selected</div>;
   }
 
-  const earlierDate = new Date(
-    Math.min(
+  const laterDate = new Date(
+    Math.max(
       new Date(blueprint.file_changed_at).getTime(),
       new Date(blueprint.file_modified_at).getTime()
     )
@@ -35,7 +35,7 @@ const BlueprintContainer = ({ blueprint }: { blueprint: Blueprint | null }) => {
     <div className='blueprintContainer'>
       <h2>{blueprint.blueprint_name}</h2>
       <p><strong>Type:</strong> {blueprint.blueprint_type}</p>
-      <p><strong>Created:</strong> {blueprint.created_at}, <strong>Updated:</strong> {earlierDate.toLocaleString()}, <strong>Size:</strong> {formatFileSize(blueprint.file_size)}</p>
+      <p><strong>Last Modified:</strong> {laterDate.toLocaleString()}, <strong>Size:</strong> {formatFileSize(blueprint.file_size)}</p>
       <p>{blueprint.tags.map(tag => (
         <button
           key={tag}

--- a/src/components/results-container.tsx
+++ b/src/components/results-container.tsx
@@ -8,6 +8,7 @@ import './results-container.css';
 const ResultsContainer = ({ onSelect }: { onSelect: (blueprint: Blueprint) => void }) => {
   const fetchBlueprints = useBlueprintStore((state) => state.fetchBlueprints);
   const blueprints = useBlueprintStore((state) => state.blueprints);
+  const paging = useBlueprintStore((state) => state.paging);
   const selectedTags = useBlueprintStore((state) => state.selectedTags);
   const removeTag = useBlueprintStore((state) => state.removeTag);
   const [selectedBlueprint, setSelectedBlueprint] = useState<Blueprint | null>(null);
@@ -25,9 +26,12 @@ const ResultsContainer = ({ onSelect }: { onSelect: (blueprint: Blueprint) => vo
     removeTag(tag);
   };
 
+  const startCount = (paging?.start_count ?? 0) + 1;
+  const endCount = startCount + blueprints.length - 1;
+
   return (
     <div className='resultsContainer'>
-      <div>Blueprints</div>
+      <h2>Blueprints</h2>
       {selectedTags.length > 0 && (
         <div className='selectedTagsContainer'>
           <div className='selectedTagsContainer__header'>Selected Tags</div>
@@ -52,6 +56,10 @@ const ResultsContainer = ({ onSelect }: { onSelect: (blueprint: Blueprint) => vo
           </li>
         ))}
       </ul>
+      
+      <div className="totalCount">
+        <strong>{startCount} - {endCount}</strong> of <strong>{paging?.total_count}</strong> that match your tags
+      </div>
     </div>
   );
 };

--- a/src/components/results-container.tsx
+++ b/src/components/results-container.tsx
@@ -60,6 +60,27 @@ const ResultsContainer = ({ onSelect }: { onSelect: (blueprint: Blueprint) => vo
       <div className="totalCount">
         <strong>{startCount} - {endCount}</strong> of <strong>{paging?.total_count}</strong> that match your tags
       </div>
+
+
+      <div className="pagination flex justify-between mt-4">
+        {paging?.previous_token && startCount > 1 &&(
+          <button
+            onClick={() => fetchBlueprints({ previous: paging.previous_token })}
+            className="px-4 py-2 text-sm bg-blue-500 text-white rounded hover:bg-blue-600"
+          >
+            Previous Page
+          </button>
+        )}
+        
+        {paging?.next_token && endCount < paging.total_count && (
+          <button
+            onClick={() => fetchBlueprints({ next: paging.next_token })}
+            className="px-4 py-2 text-sm bg-blue-500 text-white rounded hover:bg-blue-600"
+          >
+            Next Page
+          </button>
+        )}
+      </div>
     </div>
   );
 };

--- a/src/stores/blueprints-store.ts
+++ b/src/stores/blueprints-store.ts
@@ -6,7 +6,7 @@ interface StoreState {
   blueprints: Blueprint[];
   selectedTags: string[];
   paging: Paging | null;
-  fetchBlueprints: () => Promise<void>;
+  fetchBlueprints: (params?: { next?: string; previous?: string }) => Promise<void>;
   addTag: (tag: string) => void;
   removeTag: (tag: string) => void;
 }
@@ -15,9 +15,18 @@ const useStore = create<StoreState>((set, get) => ({
   blueprints: [],
   selectedTags: [],
   paging: null,
-  fetchBlueprints: async () => {
+  fetchBlueprints: async (params?: { next?: string; previous?: string }) => {
     const { selectedTags } = get();
-    const response = await fetch('/api/blueprints/tags', {
+    let url = '/api/blueprints/tags';
+
+    // Add pagination parameters if provided
+    if (params?.next) {
+      url += `?next=${params.next}`;
+    } else if (params?.previous) {
+      url += `?previous=${params.previous}`;
+    }
+    
+    const response = await fetch(url, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',

--- a/src/stores/blueprints-store.ts
+++ b/src/stores/blueprints-store.ts
@@ -1,9 +1,11 @@
 import { create } from 'zustand';
-import { Blueprint } from '@/types';
+import { Blueprint, Paging } from '@/types';
+import useTagStore from '@/stores/tag-store';
 
 interface StoreState {
   blueprints: Blueprint[];
   selectedTags: string[];
+  paging: Paging | null;
   fetchBlueprints: () => Promise<void>;
   addTag: (tag: string) => void;
   removeTag: (tag: string) => void;
@@ -12,6 +14,7 @@ interface StoreState {
 const useStore = create<StoreState>((set, get) => ({
   blueprints: [],
   selectedTags: [],
+  paging: null,
   fetchBlueprints: async () => {
     const { selectedTags } = get();
     const response = await fetch('/api/blueprints/tags', {
@@ -24,8 +27,11 @@ const useStore = create<StoreState>((set, get) => ({
       }),
     });
     const result = await response.json();
-    const blueprints = result.blueprints;
-    set({ blueprints });
+    set({ 
+      blueprints: result.blueprints,
+      paging: result.paging,
+    });
+    useTagStore.getState().setData(result.tag_counts);
   },
   addTag: (tag: string) => {
     set((state) => {

--- a/src/stores/tag-store.ts
+++ b/src/stores/tag-store.ts
@@ -41,9 +41,10 @@ import { TagNode } from '@/types';
 interface StoreState {
   data: Record<string, TagNode>;
   fetchData: () => Promise<void>;
+  setData: (tagCounts: object) => void;
 }
 
-const useStore = create<StoreState>((set) => ({
+const useStore = create<StoreState>((set, get) => ({
   data: {},
   fetchData: async () => {
     const response = await fetch('/api/blueprints/tags', {
@@ -54,7 +55,9 @@ const useStore = create<StoreState>((set) => ({
     });
     const result = await response.json();
     const tagCounts = result.tag_counts;
-
+    get().setData(tagCounts);
+  },
+  setData: (tagCounts: object) => {
     const data: Record<string, TagNode> = {};
 
     Object.entries(tagCounts).forEach(([key, count]) => {

--- a/src/types.ts
+++ b/src/types.ts
@@ -33,8 +33,8 @@ export interface TagNode {
 }
 
 export interface Paging {
-  previous_token: string | null;
-  next_token: string | null;
+  previous_token: string | undefined;
+  next_token: string | undefined;
   total_count: number;
   start_count: number;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -31,3 +31,10 @@ export interface TagNode {
   children?: Record<string, TagNode>;
   [key: string]: any;
 }
+
+export interface Paging {
+  previous_token: string | null;
+  next_token: string | null;
+  total_count: number;
+  start_count: number;
+}


### PR DESCRIPTION
Implements:

* Removing fields I don't care about showing users
* I don't have paging working in the interface, but it does now show the total and where it is in the total
* Tags in the object display are now clickable and add to the filter set.
* When you click a tag it now filters the tags so only ones that are applicable still show in the tree
* Backend now has a richer interface for paging that delivers a next token a previous token, the total count and the count of the start of the current page (zero indexed)