### PR TITLE
fix: improve sprite viewer mouse controls

### DIFF
--- a/openforge/app/index.py
+++ b/openforge/app/index.py
@@ -274,6 +274,12 @@ def image(image_id):
         return image_routes.delete_image(image_id)
 
 
+@app.route("/api/images/proxy", methods=["GET"])
+def proxy_image():
+    """Proxy image downloads to avoid CORS restrictions."""
+    return image_routes.proxy_image()
+
+
 ####################
 ### Tag Description routes
 ####################

--- a/openforge/app/routes/images.py
+++ b/openforge/app/routes/images.py
@@ -301,7 +301,9 @@ def proxy_image():
         response.raise_for_status()
 
         # Get filename from URL for download (sanitized to prevent path traversal)
-        filename = secure_filename(image_url.split("/")[-1].split("?")[0])
+        filename = secure_filename(
+            urlparse(image_url).path.split("/")[-1] or "downloaded-image"
+        )
 
         # Create response with proper headers for download
         img_response = make_response(response.content)

--- a/openforge/app/routes/images.py
+++ b/openforge/app/routes/images.py
@@ -1,5 +1,6 @@
 import json
 import uuid
+from urllib.parse import urlparse
 
 import boto3
 import requests
@@ -291,7 +292,7 @@ def proxy_image():
 
     # Only allow proxying from our R2 bucket
     file_domain = current_app.config.get("FILE_DOMAIN")
-    if not file_domain or not image_url.startswith(file_domain):
+    if not file_domain or urlparse(image_url).netloc != urlparse(file_domain).netloc:
         return jsonify({"error": "Invalid image URL"}), 400
 
     try:
@@ -299,8 +300,8 @@ def proxy_image():
         response = requests.get(image_url, timeout=30)
         response.raise_for_status()
 
-        # Get filename from URL for download
-        filename = image_url.split("/")[-1].split("?")[0]
+        # Get filename from URL for download (sanitized to prevent path traversal)
+        filename = secure_filename(image_url.split("/")[-1].split("?")[0])
 
         # Create response with proper headers for download
         img_response = make_response(response.content)

--- a/openforge/app/routes/images.py
+++ b/openforge/app/routes/images.py
@@ -290,8 +290,8 @@ def proxy_image():
         return jsonify({"error": "url parameter is required"}), 400
 
     # Only allow proxying from our R2 bucket
-    file_domain = current_app.config.get("FILE_DOMAIN", "")
-    if not image_url.startswith(file_domain):
+    file_domain = current_app.config.get("FILE_DOMAIN")
+    if not file_domain or not image_url.startswith(file_domain):
         return jsonify({"error": "Invalid image URL"}), 400
 
     try:
@@ -300,7 +300,7 @@ def proxy_image():
         response.raise_for_status()
 
         # Get filename from URL for download
-        filename = image_url.split("/")[-1]
+        filename = image_url.split("/")[-1].split("?")[0]
 
         # Create response with proper headers for download
         img_response = make_response(response.content)

--- a/openforge/app/routes/images.py
+++ b/openforge/app/routes/images.py
@@ -2,6 +2,7 @@ import json
 import uuid
 
 import boto3
+import requests
 from botocore.config import Config
 from flask import abort, current_app, jsonify, make_response, request
 from jsonschema.exceptions import ValidationError
@@ -280,3 +281,37 @@ def delete_image(image_id):
                 return make_response("", 204)
             else:
                 abort(404)
+
+
+def proxy_image():
+    """Proxy an image URL to enable downloads without CORS restrictions."""
+    image_url = request.args.get("url")
+    if not image_url:
+        return jsonify({"error": "url parameter is required"}), 400
+
+    # Only allow proxying from our R2 bucket
+    file_domain = current_app.config.get("FILE_DOMAIN", "")
+    if not image_url.startswith(file_domain):
+        return jsonify({"error": "Invalid image URL"}), 400
+
+    try:
+        # Fetch the image from R2
+        response = requests.get(image_url, timeout=30)
+        response.raise_for_status()
+
+        # Get filename from URL for download
+        filename = image_url.split("/")[-1]
+
+        # Create response with proper headers for download
+        img_response = make_response(response.content)
+        img_response.headers["Content-Type"] = response.headers.get(
+            "Content-Type", "image/png"
+        )
+        img_response.headers["Content-Disposition"] = (
+            f'attachment; filename="{filename}"'
+        )
+        return img_response
+
+    except requests.RequestException as e:
+        current_app.logger.error(f"Failed to proxy image: {e}")
+        return jsonify({"error": "Failed to fetch image"}), 500

--- a/src/components/blueprint/__tests__/sprite-viewer.test.tsx
+++ b/src/components/blueprint/__tests__/sprite-viewer.test.tsx
@@ -326,6 +326,128 @@ describe('SpriteViewer', () => {
 
       removeEventListenerSpy.mockRestore();
     });
+
+    it('does not initiate drag on right-click', () => {
+      render(<SpriteViewer blueprint={mockBlueprint} thumbnailData={mockThumbnailData} />);
+
+      const spriteElement = screen.getByLabelText(/Test Model/);
+
+      // Right-click (button 2)
+      fireEvent.mouseDown(spriteElement, { button: 2, clientX: 100 });
+
+      // Try to drag
+      fireEvent(window, new MouseEvent('mousemove', { clientX: 130, bubbles: true }));
+
+      // Should still be at front (angle 0) - no drag happened
+      const unchangedElement = screen.getByLabelText(/Test Model.*front/);
+      expect(unchangedElement.style.backgroundPosition).toBe('0px 0px');
+
+      fireEvent(window, new MouseEvent('mouseup', { bubbles: true }));
+    });
+
+    it('changes to top view when dragging vertically upward', () => {
+      render(<SpriteViewer blueprint={mockBlueprint} thumbnailData={mockThumbnailData} />);
+
+      const spriteElement = screen.getByLabelText(/Test Model/);
+
+      fireEvent.mouseDown(spriteElement, { clientX: 100, clientY: 100 });
+
+      // Drag up by more than threshold (30px)
+      fireEvent(window, new MouseEvent('mousemove', { clientX: 100, clientY: 60, bubbles: true }));
+
+      const updatedElement = screen.getByLabelText(/Test Model.*top/);
+      // Angle 8: row 1, col 3 -> position: -(3 * 512)px -(1 * 512)px = -1536px -512px
+      expect(updatedElement.style.backgroundPosition).toBe('-1536px -512px');
+
+      fireEvent(window, new MouseEvent('mouseup', { bubbles: true }));
+    });
+
+    it('changes to bottom view when dragging vertically downward', () => {
+      render(<SpriteViewer blueprint={mockBlueprint} thumbnailData={mockThumbnailData} />);
+
+      const spriteElement = screen.getByLabelText(/Test Model/);
+
+      fireEvent.mouseDown(spriteElement, { clientX: 100, clientY: 100 });
+
+      // Drag down by more than threshold (30px)
+      fireEvent(window, new MouseEvent('mousemove', { clientX: 100, clientY: 140, bubbles: true }));
+
+      const updatedElement = screen.getByLabelText(/Test Model.*bottom/);
+      // Angle 9: row 1, col 4 -> position: -(4 * 512)px -(1 * 512)px = -2048px -512px
+      expect(updatedElement.style.backgroundPosition).toBe('-2048px -512px');
+
+      fireEvent(window, new MouseEvent('mouseup', { bubbles: true }));
+    });
+
+    it('returns to front view when dragging horizontally from top view', () => {
+      const customData = { ...mockThumbnailData, default_angle: 8 }; // Start at top
+      render(<SpriteViewer blueprint={mockBlueprint} thumbnailData={customData} />);
+
+      const spriteElement = screen.getByLabelText(/Test Model/);
+
+      fireEvent.mouseDown(spriteElement, { clientX: 100, clientY: 100 });
+
+      // Drag right by more than threshold
+      fireEvent(window, new MouseEvent('mousemove', { clientX: 140, clientY: 100, bubbles: true }));
+
+      // Should go to front (angle 0) when dragging horizontally from vertical view
+      const updatedElement = screen.getByLabelText(/Test Model.*front/);
+      expect(updatedElement.style.backgroundPosition).toBe('0px 0px');
+
+      fireEvent(window, new MouseEvent('mouseup', { bubbles: true }));
+    });
+
+    it('returns to front view when dragging horizontally from bottom view', () => {
+      const customData = { ...mockThumbnailData, default_angle: 9 }; // Start at bottom
+      render(<SpriteViewer blueprint={mockBlueprint} thumbnailData={customData} />);
+
+      const spriteElement = screen.getByLabelText(/Test Model/);
+
+      fireEvent.mouseDown(spriteElement, { clientX: 100, clientY: 100 });
+
+      // Drag left by more than threshold
+      fireEvent(window, new MouseEvent('mousemove', { clientX: 60, clientY: 100, bubbles: true }));
+
+      // Should go to front (angle 0) when dragging horizontally from vertical view
+      const updatedElement = screen.getByLabelText(/Test Model.*front/);
+      expect(updatedElement.style.backgroundPosition).toBe('0px 0px');
+
+      fireEvent(window, new MouseEvent('mouseup', { bubbles: true }));
+    });
+
+    it('interprets diagonal drag as vertical when Y delta is dominant', () => {
+      render(<SpriteViewer blueprint={mockBlueprint} thumbnailData={mockThumbnailData} />);
+
+      const spriteElement = screen.getByLabelText(/Test Model/);
+
+      fireEvent.mouseDown(spriteElement, { clientX: 100, clientY: 100 });
+
+      // Diagonal drag: 20px right, 40px up (vertical is dominant)
+      fireEvent(window, new MouseEvent('mousemove', { clientX: 120, clientY: 60, bubbles: true }));
+
+      // Should go to top view (vertical wins)
+      const updatedElement = screen.getByLabelText(/Test Model.*top/);
+      expect(updatedElement.style.backgroundPosition).toBe('-1536px -512px');
+
+      fireEvent(window, new MouseEvent('mouseup', { bubbles: true }));
+    });
+
+    it('interprets diagonal drag as horizontal when X delta is dominant', () => {
+      render(<SpriteViewer blueprint={mockBlueprint} thumbnailData={mockThumbnailData} />);
+
+      const spriteElement = screen.getByLabelText(/Test Model/);
+
+      fireEvent.mouseDown(spriteElement, { clientX: 100, clientY: 100 });
+
+      // Diagonal drag: 40px right, 20px down (horizontal is dominant)
+      fireEvent(window, new MouseEvent('mousemove', { clientX: 140, clientY: 120, bubbles: true }));
+
+      // Should rotate horizontally to front-right (horizontal wins)
+      const updatedElement = screen.getByLabelText(/Test Model.*front-right/);
+      expect(updatedElement.style.backgroundPosition).toBe('-512px 0px');
+
+      fireEvent(window, new MouseEvent('mouseup', { bubbles: true }));
+    });
   });
 
   describe('Accessibility', () => {

--- a/src/components/blueprint/sprite-viewer.tsx
+++ b/src/components/blueprint/sprite-viewer.tsx
@@ -70,15 +70,21 @@ function useKeyboardRotation(
 function useMouseDragRotation(
   currentAngle: number,
   setCurrentAngle: (angle: number) => void,
-  horizontalCount: number
+  angleIndices: ReturnType<typeof getAngleIndices>
 ) {
+  const { horizontalCount, topIndex, bottomIndex } = angleIndices;
   const [isDragging, setIsDragging] = useState(false);
   const dragStartX = useRef<number>(0);
+  const dragStartY = useRef<number>(0);
   const initialAngle = useRef<number>(0);
 
   const handleMouseDown = useCallback((e: React.MouseEvent) => {
+    // Only respond to left mouse button (button 0) to avoid conflicts with context menu
+    if (e.button !== 0) return;
+
     setIsDragging(true);
     dragStartX.current = e.clientX;
+    dragStartY.current = e.clientY;
     initialAngle.current = currentAngle;
   }, [currentAngle]);
 
@@ -86,14 +92,31 @@ function useMouseDragRotation(
     if (!isDragging) return;
 
     const deltaX = e.clientX - dragStartX.current;
-    const angleChange = Math.floor(deltaX / DRAG_THRESHOLD_PX);
+    const deltaY = e.clientY - dragStartY.current;
+    const absX = Math.abs(deltaX);
+    const absY = Math.abs(deltaY);
 
-    // Only horizontal angles, wrap around
-    let newAngle = (initialAngle.current + angleChange) % horizontalCount;
-    if (newAngle < 0) newAngle += horizontalCount;
+    // Determine drag direction based on which delta is larger
+    if (absY > absX && absY > DRAG_THRESHOLD_PX) {
+      // Vertical drag: go to top or bottom
+      if (deltaY < 0) {
+        setCurrentAngle(topIndex);
+      } else {
+        setCurrentAngle(bottomIndex);
+      }
+    } else if (absX > DRAG_THRESHOLD_PX / 2) {
+      // Horizontal drag: rotate through horizontal angles
+      const angleChange = Math.floor(deltaX / DRAG_THRESHOLD_PX);
 
-    setCurrentAngle(newAngle);
-  }, [isDragging, setCurrentAngle, horizontalCount]);
+      // If initial angle was vertical, start from front (0), otherwise use initial angle
+      const baseAngle = initialAngle.current >= horizontalCount ? 0 : initialAngle.current;
+
+      let newAngle = (baseAngle + angleChange) % horizontalCount;
+      if (newAngle < 0) newAngle += horizontalCount;
+
+      setCurrentAngle(newAngle);
+    }
+  }, [isDragging, setCurrentAngle, horizontalCount, topIndex, bottomIndex]);
 
   const handleMouseUp = useCallback(() => {
     setIsDragging(false);
@@ -211,7 +234,7 @@ const SpriteViewer: React.FC<SpriteViewerProps> = ({ blueprint, thumbnailData })
 
   // Use custom hooks for event handling
   const { handleKeyDown } = useKeyboardRotation(currentAngle, setCurrentAngle, angleIndices);
-  const { handleMouseDown } = useMouseDragRotation(currentAngle, setCurrentAngle, angleIndices.horizontalCount);
+  const { handleMouseDown } = useMouseDragRotation(currentAngle, setCurrentAngle, angleIndices);
 
   // Calculate background position based on current angle
   const row = Math.floor(currentAngle / thumbnailData.grid_cols);

--- a/src/components/blueprint/sprite-viewer.tsx
+++ b/src/components/blueprint/sprite-viewer.tsx
@@ -225,6 +225,18 @@ const KeyboardHint: React.FC = () => (
   </div>
 );
 
+/**
+ * Downloads the sprite sheet image via backend proxy to avoid CORS issues
+ */
+function downloadSpriteSheet(spriteUrl: string, blueprintName: string) {
+  // Use backend proxy to download the image with proper headers
+  const proxyUrl = `/api/images/proxy?url=${encodeURIComponent(spriteUrl)}`;
+  const a = document.createElement('a');
+  a.href = proxyUrl;
+  a.download = `${blueprintName}-sprite.png`;
+  a.click();
+}
+
 const SpriteViewer: React.FC<SpriteViewerProps> = ({ blueprint, thumbnailData }) => {
   const [currentAngle, setCurrentAngle] = useState(thumbnailData.default_angle);
   const containerRef = useRef<HTMLDivElement>(null);
@@ -247,6 +259,53 @@ const SpriteViewer: React.FC<SpriteViewerProps> = ({ blueprint, thumbnailData })
     containerRef.current?.focus();
   }, []);
 
+  const handleDownload = () => {
+    downloadSpriteSheet(thumbnailData.sprite_url, blueprint.blueprint_name);
+  };
+
+  const handleContextMenu = (e: React.MouseEvent) => {
+    e.preventDefault();
+    // Create a simple context menu
+    const contextMenu = document.createElement('div');
+    contextMenu.style.position = 'fixed';
+    contextMenu.style.left = `${e.clientX}px`;
+    contextMenu.style.top = `${e.clientY}px`;
+    contextMenu.style.backgroundColor = 'white';
+    contextMenu.style.border = '1px solid #ccc';
+    contextMenu.style.borderRadius = '4px';
+    contextMenu.style.boxShadow = '0 2px 8px rgba(0,0,0,0.15)';
+    contextMenu.style.zIndex = '10000';
+    contextMenu.style.padding = '4px 0';
+
+    const downloadOption = document.createElement('div');
+    downloadOption.textContent = 'Download sprite sheet';
+    downloadOption.style.padding = '8px 16px';
+    downloadOption.style.cursor = 'pointer';
+    downloadOption.style.fontSize = '14px';
+    downloadOption.onmouseover = () => {
+      downloadOption.style.backgroundColor = '#f0f0f0';
+    };
+    downloadOption.onmouseout = () => {
+      downloadOption.style.backgroundColor = 'white';
+    };
+    downloadOption.onclick = () => {
+      handleDownload();
+      document.body.removeChild(contextMenu);
+    };
+
+    contextMenu.appendChild(downloadOption);
+    document.body.appendChild(contextMenu);
+
+    // Remove menu when clicking elsewhere
+    const removeMenu = () => {
+      if (document.body.contains(contextMenu)) {
+        document.body.removeChild(contextMenu);
+      }
+      document.removeEventListener('click', removeMenu);
+    };
+    setTimeout(() => document.addEventListener('click', removeMenu), 0);
+  };
+
   return (
     <div
       ref={containerRef}
@@ -256,19 +315,30 @@ const SpriteViewer: React.FC<SpriteViewerProps> = ({ blueprint, thumbnailData })
       tabIndex={0}
     >
       <div className="flex gap-4 items-center">
-        <div
-          className="cursor-grab active:cursor-grabbing rounded"
-          style={{
-            backgroundImage: `url(${thumbnailData.sprite_url})`,
-            backgroundPosition: `${backgroundPositionX}px ${backgroundPositionY}px`,
-            width: `${thumbnailData.tile_size}px`,
-            height: `${thumbnailData.tile_size}px`,
-            backgroundRepeat: 'no-repeat',
-            userSelect: 'none'
-          }}
-          onMouseDown={handleMouseDown}
-          aria-label={`${blueprint.blueprint_name} - 3D model view, current angle: ${thumbnailData.angles[currentAngle]?.name || currentAngle}`}
-        />
+        <div className="relative">
+          <div
+            className="cursor-grab active:cursor-grabbing rounded"
+            style={{
+              backgroundImage: `url(${thumbnailData.sprite_url})`,
+              backgroundPosition: `${backgroundPositionX}px ${backgroundPositionY}px`,
+              width: `${thumbnailData.tile_size}px`,
+              height: `${thumbnailData.tile_size}px`,
+              backgroundRepeat: 'no-repeat',
+              userSelect: 'none'
+            }}
+            onMouseDown={handleMouseDown}
+            onContextMenu={handleContextMenu}
+            aria-label={`${blueprint.blueprint_name} - 3D model view, current angle: ${thumbnailData.angles[currentAngle]?.name || currentAngle}`}
+          />
+          <button
+            onClick={handleDownload}
+            className="absolute bottom-2 right-2 bg-black bg-opacity-50 hover:bg-opacity-70 text-white rounded px-2 py-1 text-xs"
+            title="Download current view"
+            type="button"
+          >
+            ⬇
+          </button>
+        </div>
 
         <SpriteControls
           currentAngle={currentAngle}

--- a/src/components/blueprint/sprite-viewer.tsx
+++ b/src/components/blueprint/sprite-viewer.tsx
@@ -97,24 +97,25 @@ function useMouseDragRotation(
     const absY = Math.abs(deltaY);
 
     // Determine drag direction based on which delta is larger
-    if (absY > absX && absY > DRAG_THRESHOLD_PX) {
+    if (absY > absX && absY >= DRAG_THRESHOLD_PX) {
       // Vertical drag: go to top or bottom
       if (deltaY < 0) {
         setCurrentAngle(topIndex);
       } else {
         setCurrentAngle(bottomIndex);
       }
-    } else if (absX > DRAG_THRESHOLD_PX / 2) {
+    } else if (absX > absY && absX >= DRAG_THRESHOLD_PX) {
       // Horizontal drag: rotate through horizontal angles
-      const angleChange = Math.floor(deltaX / DRAG_THRESHOLD_PX);
-
-      // If initial angle was vertical, start from front (0), otherwise use initial angle
-      const baseAngle = initialAngle.current >= horizontalCount ? 0 : initialAngle.current;
-
-      let newAngle = (baseAngle + angleChange) % horizontalCount;
-      if (newAngle < 0) newAngle += horizontalCount;
-
-      setCurrentAngle(newAngle);
+      // If initial angle was vertical, just go to front (0) without calculating rotation
+      if (initialAngle.current >= horizontalCount) {
+        setCurrentAngle(0);
+      } else {
+        // Normal horizontal rotation from a horizontal starting angle
+        const angleChange = Math.floor(deltaX / DRAG_THRESHOLD_PX);
+        let newAngle = (initialAngle.current + angleChange) % horizontalCount;
+        if (newAngle < 0) newAngle += horizontalCount;
+        setCurrentAngle(newAngle);
+      }
     }
   }, [isDragging, setCurrentAngle, horizontalCount, topIndex, bottomIndex]);
 

--- a/src/components/blueprint/sprite-viewer.tsx
+++ b/src/components/blueprint/sprite-viewer.tsx
@@ -107,7 +107,10 @@ function useMouseDragRotation(
     } else if (absX > absY && absX >= DRAG_THRESHOLD_PX) {
       // Horizontal drag: rotate through horizontal angles
       // If initial angle was vertical, just go to front (0) without calculating rotation
-      if (initialAngle.current >= horizontalCount) {
+      if (
+        initialAngle.current === topIndex ||
+        initialAngle.current === bottomIndex
+      ) {
         setCurrentAngle(0);
       } else {
         // Normal horizontal rotation from a horizontal starting angle

--- a/src/components/blueprint/sprite-viewer.tsx
+++ b/src/components/blueprint/sprite-viewer.tsx
@@ -241,6 +241,7 @@ function downloadSpriteSheet(spriteUrl: string, blueprintName: string) {
 const SpriteViewer: React.FC<SpriteViewerProps> = ({ blueprint, thumbnailData }) => {
   const [currentAngle, setCurrentAngle] = useState(thumbnailData.default_angle);
   const containerRef = useRef<HTMLDivElement>(null);
+  const contextMenuCleanupRef = useRef<(() => void) | null>(null);
 
   // Derive angle indices from sprite metadata
   const angleIndices = getAngleIndices(thumbnailData.angles);
@@ -260,12 +261,27 @@ const SpriteViewer: React.FC<SpriteViewerProps> = ({ blueprint, thumbnailData })
     containerRef.current?.focus();
   }, []);
 
+  // Cleanup context menu on unmount
+  useEffect(() => {
+    return () => {
+      if (contextMenuCleanupRef.current) {
+        contextMenuCleanupRef.current();
+      }
+    };
+  }, []);
+
   const handleDownload = () => {
     downloadSpriteSheet(thumbnailData.sprite_url, blueprint.blueprint_name);
   };
 
   const handleContextMenu = (e: React.MouseEvent) => {
     e.preventDefault();
+
+    // Clean up any existing context menu
+    if (contextMenuCleanupRef.current) {
+      contextMenuCleanupRef.current();
+    }
+
     // Create a simple context menu
     const contextMenu = document.createElement('div');
     contextMenu.style.position = 'fixed';
@@ -292,6 +308,7 @@ const SpriteViewer: React.FC<SpriteViewerProps> = ({ blueprint, thumbnailData })
     downloadOption.onclick = () => {
       handleDownload();
       document.body.removeChild(contextMenu);
+      contextMenuCleanupRef.current = null;
     };
 
     contextMenu.appendChild(downloadOption);
@@ -303,7 +320,11 @@ const SpriteViewer: React.FC<SpriteViewerProps> = ({ blueprint, thumbnailData })
         document.body.removeChild(contextMenu);
       }
       document.removeEventListener('click', removeMenu);
+      contextMenuCleanupRef.current = null;
     };
+
+    // Store cleanup function for component unmount
+    contextMenuCleanupRef.current = removeMenu;
     setTimeout(() => document.addEventListener('click', removeMenu), 0);
   };
 
@@ -334,7 +355,7 @@ const SpriteViewer: React.FC<SpriteViewerProps> = ({ blueprint, thumbnailData })
           <button
             onClick={handleDownload}
             className="absolute bottom-2 right-2 bg-black bg-opacity-50 hover:bg-opacity-70 text-white rounded px-2 py-1 text-xs"
-            title="Download current view"
+            title="Download sprite sheet"
             type="button"
           >
             ⬇


### PR DESCRIPTION
## Summary
- Fixed right-click drag conflict with context menu
- Added vertical drag support for top/bottom views
- Fixed rotation math when transitioning between vertical and horizontal views
- Added sprite sheet download functionality via backend proxy

## Mouse Control Changes
- Only left mouse button triggers dragging (right-click now shows context menu properly)
- Drag up switches to top view
- Drag down switches to bottom view
- Horizontal drag from vertical views correctly goes to front view first
- Atomic drag gestures (either horizontal OR vertical, not mixed)

## Download Functionality
- Added download button in bottom-right corner of sprite viewer
- Added right-click context menu with "Download sprite sheet" option
- Created backend proxy endpoint `/api/images/proxy` to bypass CORS restrictions
- Downloads full sprite sheet (extracting single tiles blocked by CORS)

## Technical Details
- CORS prevents canvas manipulation and download of cross-origin images
- Backend proxy fetches images server-side and adds Content-Disposition header
- Proxy validates URLs are from FILE_DOMAIN for security

## Testing
- All existing tests pass
- Keyboard controls unchanged and working
- Mouse drag rotation works correctly from all angles

🤖 Generated with [Claude Code](https://claude.com/claude-code)